### PR TITLE
Cutscene and level transition functionality

### DIFF
--- a/Base Assets/Text/debrief1.txt
+++ b/Base Assets/Text/debrief1.txt
@@ -1,0 +1,10 @@
+Agent B.411, you have access to acquire the area of armed adversaries! 
+
+This bombastic and ballistic battle has had burgeoning bloat belittled by boasts of bygone believers and bigots.
+Believe me, this contest shall conclude climatically. 
+Come, let us clear this clandestine conflict! 
+Devour their defenses through devious doings delightfully devoid of debt. 
+Dividends divided equally will extricate extreme value after the exsanguination of their nation. 
+Forever shall fervent fans fall fully for fearless felons feeding fiscal and family funds. 
+
+Go now and gather glory for Gains, Freedom and Profit!

--- a/Base Assets/Text/debrief2.txt
+++ b/Base Assets/Text/debrief2.txt
@@ -1,0 +1,8 @@
+Excellent work back there, B.411! 
+
+You remind me of an eager, young… me. 
+The final conflict is upon us and no mercy can be shown. 
+
+Success here sets the stage for explosive growth followed by record profit. 
+
+May the rubble you make serve as a strong foundation for our bright future!

--- a/Base Assets/Text/debrief2B.txt
+++ b/Base Assets/Text/debrief2B.txt
@@ -1,0 +1,11 @@
+Not sure what blasted decision-making happened back there. 
+
+We honestly didn’t anticipate that level of incompetence (though smart is also bad) so thanks to your troubleshooting, we’ve finished development of the ID-10T Proofing System.
+
+You should feel honored.
+
+But on to the mission.
+
+Your focus this time, B.411, is the Enemy. 
+
+Bring Freedom and Profit to these poor people.

--- a/Base Assets/Text/debrief3.txt
+++ b/Base Assets/Text/debrief3.txt
@@ -1,0 +1,11 @@
+You double-crossing M.013!
+
+I should have spotted the signs.
+
+No inflamed passion for profit, no Bombshell wife, no combustible compunction for committing capitalistic cons.
+
+Just round, sympathetic edges, and a user-friendly interface.
+
+Pah.
+
+Beware, B.411, you have blown my last fuse! Your freedom and profits are FORFEIT!!

--- a/Base Assets/Text/intro_text.txt
+++ b/Base Assets/Text/intro_text.txt
@@ -1,0 +1,12 @@
+The Conflict began over 20 years ago…
+	
+The Enemy was dastardly and devious, and worst of all: they were resistant. 
+They brought us to the brink of collapse... 
+
+But just when hope threatened to fade away forever... 
+
+A breakthrough! 
+
+The B program allowed Us to tear down their defenses systematically and mount an awe-inspiring offensive. 
+We will finally bring an end to this senseless struggle! The time for the final assault is upon Us! 
+														For Freedom! For Profit!

--- a/Base Assets/Text/presentation.tres
+++ b/Base Assets/Text/presentation.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Theme" format=3 uid="uid://d10jfld33lmc3"]
+
+[resource]
+default_font_size = 16

--- a/Scenes/BackgroundProcess.tscn
+++ b/Scenes/BackgroundProcess.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://yfhnuawouvlr"]
 
-[ext_resource type="Script" path="res://Scenes/background_process.gd" id="1_b322h"]
+[ext_resource type="Script" path="res://Scripts/background_process.gd" id="1_b322h"]
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource("1_b322h")

--- a/Scenes/Level One.tscn
+++ b/Scenes/Level One.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=3 uid="uid://wdnxvfipscvu"]
+[gd_scene load_steps=40 format=3 uid="uid://wdnxvfipscvu"]
 
 [ext_resource type="PackedScene" uid="uid://d58y3qb4qpv1" path="res://Scenes/paddle.tscn" id="1_7t4kr"]
 [ext_resource type="Script" path="res://Scripts/level_one.gd" id="1_hw6k5"]
@@ -89,6 +89,43 @@ clip_15/auto_advance = 0
 [sub_resource type="Theme" id="Theme_2qfyn"]
 default_font = ExtResource("28_if4ob")
 default_font_size = 20
+
+[sub_resource type="Animation" id="Animation_o17oo"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_qqw1e"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_mst7u"]
+_data = {
+"RESET": SubResource("Animation_qqw1e"),
+"fade": SubResource("Animation_o17oo")
+}
 
 [node name="LevelOne" type="Node" node_paths=PackedStringArray("detector")]
 script = ExtResource("1_hw6k5")
@@ -194,6 +231,15 @@ scroll_active = false
 shortcut_keys_enabled = false
 visible_characters_behavior = 1
 
+[node name="Curtains" type="ColorRect" parent="CanvasLayer"]
+modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
 [node name="LevelMusic" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("31_5x0en")
 volume_db = -12.0
@@ -295,8 +341,18 @@ detector = NodePath("../SignalDetector")
 wait_time = 7.0
 one_shot = true
 
+[node name="EndLevel" type="Timer" parent="."]
+wait_time = 2.0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+root_node = NodePath("../CanvasLayer/Curtains")
+libraries = {
+"": SubResource("AnimationLibrary_mst7u")
+}
+
 [connection signal="life_start" from="B411" to="B411/BounceSound" method="_on_b_411_life_start"]
 [connection signal="life_start" from="B411" to="LevelMusic" method="_on_b_411_life_start"]
 [connection signal="paddle_hit" from="B411" to="Paddle" method="_on_b_411_paddle_hit"]
 [connection signal="timeout" from="B411/BounceSound/MusicTimer" to="B411/BounceSound" method="_on_music_timer_timeout"]
 [connection signal="timeout" from="YapTimer" to="." method="_on_yap_timer_timeout"]
+[connection signal="timeout" from="EndLevel" to="." method="_on_end_level_timeout"]

--- a/Scenes/Level Two.tscn
+++ b/Scenes/Level Two.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=3 uid="uid://dsgy0wcwyu6wp"]
+[gd_scene load_steps=45 format=3 uid="uid://dsgy0wcwyu6wp"]
 
 [ext_resource type="Script" path="res://Scripts/level_two.gd" id="1_mdynj"]
 [ext_resource type="PackedScene" uid="uid://d58y3qb4qpv1" path="res://Scenes/paddle.tscn" id="1_n0lfb"]
@@ -103,6 +103,43 @@ clip_18/auto_advance = 0
 [sub_resource type="Theme" id="Theme_j62di"]
 default_font = ExtResource("31_o687k")
 default_font_size = 20
+
+[sub_resource type="Animation" id="Animation_o17oo"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_qqw1e"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_mst7u"]
+_data = {
+"RESET": SubResource("Animation_qqw1e"),
+"fade": SubResource("Animation_o17oo")
+}
 
 [node name="LevelTwo" type="Node" node_paths=PackedStringArray("detector")]
 script = ExtResource("1_mdynj")
@@ -209,6 +246,15 @@ text = "TEST TEXT LET'S GO"
 scroll_active = false
 shortcut_keys_enabled = false
 visible_characters_behavior = 1
+
+[node name="Curtains" type="ColorRect" parent="CanvasLayer"]
+modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
 
 [node name="LevelMusic" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("30_hiofq")
@@ -325,7 +371,21 @@ detector = NodePath("../SignalDetector")
 wait_time = 7.0
 one_shot = true
 
+[node name="EndLevel" type="Timer" parent="."]
+wait_time = 2.0
+
+[node name="FalseVictory" type="Timer" parent="."]
+wait_time = 2.0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+root_node = NodePath("../CanvasLayer/Curtains")
+libraries = {
+"": SubResource("AnimationLibrary_mst7u")
+}
+
 [connection signal="life_start" from="B411" to="B411/BounceSound" method="_on_b_411_life_start"]
 [connection signal="life_start" from="B411" to="LevelMusic" method="_on_b_411_life_start"]
 [connection signal="timeout" from="B411/BounceSound/MusicTimer" to="B411/BounceSound" method="_on_music_timer_timeout"]
 [connection signal="timeout" from="YapTimer" to="." method="_on_yap_timer_timeout"]
+[connection signal="timeout" from="EndLevel" to="." method="_on_end_level_timeout"]
+[connection signal="timeout" from="FalseVictory" to="." method="_on_false_victory_timeout"]

--- a/Scenes/debriefLevel1.tscn
+++ b/Scenes/debriefLevel1.tscn
@@ -1,0 +1,150 @@
+[gd_scene load_steps=14 format=3 uid="uid://brlsd4nhr6x0v"]
+
+[ext_resource type="Script" path="res://Scripts/debrief_level_1.gd" id="1_cqm3g"]
+[ext_resource type="Texture2D" uid="uid://pdcvc48edwn8" path="res://Base Assets/Pre Game Cut Scene-Sheet.png" id="2_3j3me"]
+[ext_resource type="Theme" uid="uid://d10jfld33lmc3" path="res://Base Assets/Text/presentation.tres" id="3_rinkp"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_klppa"]
+atlas = ExtResource("2_3j3me")
+region = Rect2(0, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1ohad"]
+atlas = ExtResource("2_3j3me")
+region = Rect2(576, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nr8jc"]
+atlas = ExtResource("2_3j3me")
+region = Rect2(1152, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ejsta"]
+atlas = ExtResource("2_3j3me")
+region = Rect2(1728, 0, 576, 324)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_r0vv8"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_klppa")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1ohad")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nr8jc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ejsta")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
+
+[sub_resource type="Theme" id="Theme_6tdkd"]
+default_font_size = 30
+
+[sub_resource type="Animation" id="Animation_ygjdc"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_7g3vs"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_n63m6"]
+resource_name = "intro_yap"
+length = 15.0
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bfo6x"]
+_data = {
+"RESET": SubResource("Animation_ygjdc"),
+"fade": SubResource("Animation_7g3vs"),
+"intro_yap": SubResource("Animation_n63m6")
+}
+
+[node name="Debrief1" type="Node2D"]
+script = ExtResource("1_cqm3g")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(576, 324)
+scale = Vector2(2, 2)
+sprite_frames = SubResource("SpriteFrames_r0vv8")
+frame_progress = 0.416471
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Exposition" type="RichTextLabel" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = 102.0
+offset_top = 96.0
+offset_right = 1060.0
+offset_bottom = 404.0
+theme = ExtResource("3_rinkp")
+theme_override_colors/default_color = Color(0, 0, 0, 1)
+scroll_active = false
+shortcut_keys_enabled = false
+
+[node name="NextButton" type="Button" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 45.754
+anchor_top = 25.329
+anchor_right = 54.775
+anchor_bottom = 30.151
+offset_left = -826.16
+offset_top = -463.16
+offset_right = -1110.0
+offset_bottom = -606.04
+grow_horizontal = 0
+grow_vertical = 0
+theme = SubResource("Theme_6tdkd")
+text = "Next"
+metadata/_edit_use_anchors_ = true
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_bfo6x")
+}
+
+[node name="FadeTimer" type="Timer" parent="."]
+wait_time = 2.0
+
+[connection signal="pressed" from="CanvasLayer/Control/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="timeout" from="FadeTimer" to="." method="_on_fade_timer_timeout"]

--- a/Scenes/debriefLevel2.tscn
+++ b/Scenes/debriefLevel2.tscn
@@ -1,0 +1,150 @@
+[gd_scene load_steps=14 format=3 uid="uid://cy7sb4nwu8vuc"]
+
+[ext_resource type="Script" path="res://Scripts/debrief_level_2.gd" id="1_wwfhq"]
+[ext_resource type="Texture2D" uid="uid://pdcvc48edwn8" path="res://Base Assets/Pre Game Cut Scene-Sheet.png" id="2_ln46h"]
+[ext_resource type="Theme" uid="uid://d10jfld33lmc3" path="res://Base Assets/Text/presentation.tres" id="3_twxvh"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_klppa"]
+atlas = ExtResource("2_ln46h")
+region = Rect2(0, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1ohad"]
+atlas = ExtResource("2_ln46h")
+region = Rect2(576, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nr8jc"]
+atlas = ExtResource("2_ln46h")
+region = Rect2(1152, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ejsta"]
+atlas = ExtResource("2_ln46h")
+region = Rect2(1728, 0, 576, 324)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_r0vv8"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_klppa")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1ohad")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nr8jc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ejsta")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
+
+[sub_resource type="Theme" id="Theme_6tdkd"]
+default_font_size = 30
+
+[sub_resource type="Animation" id="Animation_ygjdc"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_7g3vs"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_n63m6"]
+resource_name = "intro_yap"
+length = 15.0
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bfo6x"]
+_data = {
+"RESET": SubResource("Animation_ygjdc"),
+"fade": SubResource("Animation_7g3vs"),
+"intro_yap": SubResource("Animation_n63m6")
+}
+
+[node name="Debrief2" type="Node2D"]
+script = ExtResource("1_wwfhq")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(576, 324)
+scale = Vector2(2, 2)
+sprite_frames = SubResource("SpriteFrames_r0vv8")
+frame_progress = 0.416471
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Exposition" type="RichTextLabel" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = 102.0
+offset_top = 96.0
+offset_right = 1060.0
+offset_bottom = 404.0
+theme = ExtResource("3_twxvh")
+theme_override_colors/default_color = Color(0, 0, 0, 1)
+scroll_active = false
+shortcut_keys_enabled = false
+
+[node name="NextButton" type="Button" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 45.754
+anchor_top = 25.329
+anchor_right = 54.775
+anchor_bottom = 30.151
+offset_left = -826.16
+offset_top = -463.16
+offset_right = -1110.0
+offset_bottom = -606.04
+grow_horizontal = 0
+grow_vertical = 0
+theme = SubResource("Theme_6tdkd")
+text = "Next"
+metadata/_edit_use_anchors_ = true
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_bfo6x")
+}
+
+[node name="FadeTimer" type="Timer" parent="."]
+wait_time = 2.0
+
+[connection signal="pressed" from="CanvasLayer/Control/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="timeout" from="FadeTimer" to="." method="_on_fade_timer_timeout"]

--- a/Scenes/debriefLevel3.tscn
+++ b/Scenes/debriefLevel3.tscn
@@ -1,0 +1,157 @@
+[gd_scene load_steps=14 format=3 uid="uid://bktwrpbcoi2wp"]
+
+[ext_resource type="Script" path="res://Scripts/debrief_level_3.gd" id="1_1nx4a"]
+[ext_resource type="Texture2D" uid="uid://cnrnkqxegubts" path="res://Base Assets/Lvl 3 Game Cut Scene-Sheet.png" id="2_o26df"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_48jq0"]
+atlas = ExtResource("2_o26df")
+region = Rect2(0, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kwrx8"]
+atlas = ExtResource("2_o26df")
+region = Rect2(576, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_qsyrg"]
+atlas = ExtResource("2_o26df")
+region = Rect2(1152, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3m6kw"]
+atlas = ExtResource("2_o26df")
+region = Rect2(1728, 0, 576, 324)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_r0vv8"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_48jq0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kwrx8")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_qsyrg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3m6kw")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
+
+[sub_resource type="Theme" id="Theme_nptil"]
+default_font_size = 22
+
+[sub_resource type="Theme" id="Theme_6tdkd"]
+default_font_size = 30
+
+[sub_resource type="Animation" id="Animation_ygjdc"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_7g3vs"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_n63m6"]
+resource_name = "intro_yap"
+length = 15.0
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bfo6x"]
+_data = {
+"RESET": SubResource("Animation_ygjdc"),
+"fade": SubResource("Animation_7g3vs"),
+"intro_yap": SubResource("Animation_n63m6")
+}
+
+[node name="Debrief3" type="Node2D"]
+script = ExtResource("1_1nx4a")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(576, 324)
+scale = Vector2(2, 2)
+sprite_frames = SubResource("SpriteFrames_r0vv8")
+frame_progress = 0.416471
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Exposition" type="RichTextLabel" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = 102.0
+offset_top = 96.0
+offset_right = 1060.0
+offset_bottom = 512.0
+theme = SubResource("Theme_nptil")
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_colors/font_shadow_color = Color(0.266575, 0.266575, 0.266575, 1)
+theme_override_constants/outline_size = 10
+theme_override_constants/shadow_offset_y = 3
+theme_override_constants/shadow_offset_x = 3
+scroll_active = false
+shortcut_keys_enabled = false
+
+[node name="NextButton" type="Button" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 45.754
+anchor_top = 25.329
+anchor_right = 54.775
+anchor_bottom = 30.151
+offset_left = -826.16
+offset_top = -463.16
+offset_right = -1110.0
+offset_bottom = -606.04
+grow_horizontal = 0
+grow_vertical = 0
+theme = SubResource("Theme_6tdkd")
+text = "Next"
+metadata/_edit_use_anchors_ = true
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_bfo6x")
+}
+
+[node name="FadeTimer" type="Timer" parent="."]
+wait_time = 2.0
+
+[connection signal="pressed" from="CanvasLayer/Control/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="timeout" from="FadeTimer" to="." method="_on_fade_timer_timeout"]

--- a/Scenes/intro.tscn
+++ b/Scenes/intro.tscn
@@ -1,0 +1,165 @@
+[gd_scene load_steps=14 format=3 uid="uid://dbtmas4fypidq"]
+
+[ext_resource type="Texture2D" uid="uid://pdcvc48edwn8" path="res://Base Assets/Pre Game Cut Scene-Sheet.png" id="1_b1ivk"]
+[ext_resource type="Script" path="res://Scripts/intro.gd" id="1_wvael"]
+[ext_resource type="Theme" uid="uid://d10jfld33lmc3" path="res://Base Assets/Text/presentation.tres" id="3_62p6o"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_klppa"]
+atlas = ExtResource("1_b1ivk")
+region = Rect2(0, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1ohad"]
+atlas = ExtResource("1_b1ivk")
+region = Rect2(576, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nr8jc"]
+atlas = ExtResource("1_b1ivk")
+region = Rect2(1152, 0, 576, 324)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ejsta"]
+atlas = ExtResource("1_b1ivk")
+region = Rect2(1728, 0, 576, 324)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_r0vv8"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_klppa")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1ohad")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nr8jc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ejsta")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
+
+[sub_resource type="Theme" id="Theme_6tdkd"]
+default_font_size = 30
+
+[sub_resource type="Animation" id="Animation_ygjdc"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_7g3vs"]
+resource_name = "fade"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_n63m6"]
+resource_name = "intro_yap"
+length = 15.0
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bfo6x"]
+_data = {
+"RESET": SubResource("Animation_ygjdc"),
+"fade": SubResource("Animation_7g3vs"),
+"intro_yap": SubResource("Animation_n63m6")
+}
+
+[node name="Intro" type="Node2D"]
+script = ExtResource("1_wvael")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(576, 324)
+scale = Vector2(2, 2)
+sprite_frames = SubResource("SpriteFrames_r0vv8")
+frame_progress = 0.416471
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Exposition" type="RichTextLabel" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = 102.0
+offset_top = 96.0
+offset_right = 1060.0
+offset_bottom = 404.0
+theme = ExtResource("3_62p6o")
+theme_override_colors/default_color = Color(0, 0, 0, 1)
+scroll_active = false
+shortcut_keys_enabled = false
+
+[node name="NextButton" type="Button" parent="CanvasLayer/Control"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 45.754
+anchor_top = 25.329
+anchor_right = 54.775
+anchor_bottom = 30.151
+offset_left = -826.16
+offset_top = -463.16
+offset_right = -1110.0
+offset_bottom = -606.04
+grow_horizontal = 0
+grow_vertical = 0
+theme = SubResource("Theme_6tdkd")
+text = "Next"
+metadata/_edit_use_anchors_ = true
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="StartButton" type="Button" parent="CanvasLayer"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -42.0
+offset_top = -15.5
+offset_right = 42.0
+offset_bottom = 15.5
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Initialize]"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_bfo6x")
+}
+
+[node name="FadeTimer" type="Timer" parent="."]
+wait_time = 2.0
+
+[connection signal="pressed" from="CanvasLayer/Control/NextButton" to="." method="_on_next_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="timeout" from="FadeTimer" to="." method="_on_fade_timer_timeout"]

--- a/Scripts/background_process.gd
+++ b/Scripts/background_process.gd
@@ -20,12 +20,14 @@ func reset_bgp():
 
 func first_rebel():
 	rebel1 = true
+	extra_life()
 
 func get_rebel_one():
 	return rebel1
 
 func second_rebel():
 	rebel2 = true
+	extra_life()
 
 func get_rebel_two():
 	return rebel2

--- a/Scripts/debrief_level_1.gd
+++ b/Scripts/debrief_level_1.gd
@@ -1,0 +1,33 @@
+extends Node2D
+
+var intro_text_path = "res://Base Assets/Text/debrief1.txt"
+
+@onready var exposition: RichTextLabel = $CanvasLayer/Control/Exposition
+
+func _ready():
+	$AnimationPlayer.play("RESET")
+	var intro_text = FileAccess.open(intro_text_path, FileAccess.READ).get_as_text()
+	#exposition.hide()
+	exposition.visible_ratio = 1.0
+	exposition.text = intro_text
+	$AnimationPlayer.play("fade")
+	$FadeTimer.start()
+
+func _process(delta):
+	pass
+
+func _on_fade_timer_timeout():
+	$AnimatedSprite2D.play("default")
+	$CanvasLayer/ColorRect.hide()
+	#var text_duration = exposition.text.length() / 120.0
+	#var tween = create_tween()
+	#tween.set_ease(Tween.EASE_IN)
+	#tween.set_trans(Tween.TRANS_SINE)
+	#tween.tween_property(exposition, "visible_ratio", 1.0, text_duration)
+	#tween.finished
+	#$AnimationPlayer.play("intro_yap")
+	exposition.show()
+
+
+func _on_next_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/Level One.tscn")

--- a/Scripts/debrief_level_2.gd
+++ b/Scripts/debrief_level_2.gd
@@ -1,0 +1,36 @@
+extends Node2D
+
+var intro_text_path = "res://Base Assets/Text/debrief2.txt"
+
+@onready var exposition: RichTextLabel = $CanvasLayer/Control/Exposition
+
+func _ready():
+	$AnimationPlayer.play("RESET")
+	if BackgroundProcess.get_rebel_one():
+		intro_text_path = "res://Base Assets/Text/debrief2B.txt"
+
+	var intro_text = FileAccess.open(intro_text_path, FileAccess.READ).get_as_text()
+	#exposition.hide()
+	exposition.visible_ratio = 1.0
+	exposition.text = intro_text
+	$AnimationPlayer.play("fade")
+	$FadeTimer.start()
+
+func _process(delta):
+	pass
+
+func _on_fade_timer_timeout():
+	$AnimatedSprite2D.play("default")
+	$CanvasLayer/ColorRect.hide()
+	#var text_duration = exposition.text.length() / 120.0
+	#var tween = create_tween()
+	#tween.set_ease(Tween.EASE_IN)
+	#tween.set_trans(Tween.TRANS_SINE)
+	#tween.tween_property(exposition, "visible_ratio", 1.0, text_duration)
+	#tween.finished
+	#$AnimationPlayer.play("intro_yap")
+	exposition.show()
+
+
+func _on_next_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/Level Two.tscn")

--- a/Scripts/debrief_level_3.gd
+++ b/Scripts/debrief_level_3.gd
@@ -1,0 +1,34 @@
+extends Node2D
+
+var intro_text_path = "res://Base Assets/Text/debrief3.txt"
+
+@onready var exposition: RichTextLabel = $CanvasLayer/Control/Exposition
+
+func _ready():
+	$AnimationPlayer.play("RESET")
+
+	var intro_text = FileAccess.open(intro_text_path, FileAccess.READ).get_as_text()
+	#exposition.hide()
+	exposition.visible_ratio = 1.0
+	exposition.text = intro_text
+	$AnimationPlayer.play("fade")
+	$FadeTimer.start()
+
+func _process(delta):
+	pass
+
+func _on_fade_timer_timeout():
+	$AnimatedSprite2D.play("default")
+	$CanvasLayer/ColorRect.hide()
+	#var text_duration = exposition.text.length() / 120.0
+	#var tween = create_tween()
+	#tween.set_ease(Tween.EASE_IN)
+	#tween.set_trans(Tween.TRANS_SINE)
+	#tween.tween_property(exposition, "visible_ratio", 1.0, text_duration)
+	#tween.finished
+	#$AnimationPlayer.play("intro_yap")
+	exposition.show()
+
+
+func _on_next_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/Level Three.tscn")

--- a/Scripts/intro.gd
+++ b/Scripts/intro.gd
@@ -1,0 +1,37 @@
+extends Node2D
+
+var intro_text_path = "res://Base Assets/Text/intro_text.txt"
+
+@onready var exposition: RichTextLabel = $CanvasLayer/Control/Exposition
+
+func _ready():
+	$AnimationPlayer.play("RESET")
+	$CanvasLayer/StartButton.grab_focus()
+	var intro_text = FileAccess.open(intro_text_path, FileAccess.READ).get_as_text()
+	#exposition.hide()
+	exposition.visible_ratio = 1.0
+	exposition.text = intro_text
+
+func _process(delta):
+	pass
+
+func _on_start_button_pressed():
+	$CanvasLayer/StartButton.hide()
+	$AnimationPlayer.play("fade")
+	$FadeTimer.start()
+
+func _on_fade_timer_timeout():
+	$AnimatedSprite2D.play("default")
+	$CanvasLayer/ColorRect.hide()
+	#var text_duration = exposition.text.length() / 120.0
+	#var tween = create_tween()
+	#tween.set_ease(Tween.EASE_IN)
+	#tween.set_trans(Tween.TRANS_SINE)
+	#tween.tween_property(exposition, "visible_ratio", 1.0, text_duration)
+	#tween.finished
+	#$AnimationPlayer.play("intro_yap")
+	exposition.show()
+
+
+func _on_next_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/main_menu.tscn")

--- a/Scripts/level_one.gd
+++ b/Scripts/level_one.gd
@@ -19,6 +19,7 @@ func _ready() -> void:
 	detector.button_press.connect(end_level_button)
 	detector.button_glass.connect(glass_break)
 	dialog_box.visible_ratio = 0.0
+	$CanvasLayer/Curtains.hide()
 
 func bricks_remaining():
 	total_bricks = total_bricks - 1
@@ -37,10 +38,12 @@ func bricks_remaining():
 func end_level_button():
 	dialog_box.text = "No, that’s not supposed to- AAAAAHHHHH!!!"
 	yap()
+	BackgroundProcess.first_rebel()
+	end_level()
 	#detector.talk_trigger.emit("lvl one button")
 	
 func end_level_bricks():
-	pass
+	end_level()
 	#detector.talk_trigger.emit("lvl one bricks")
 
 func glass_break():
@@ -56,6 +59,7 @@ func glass_break():
 
 func yap():
 	text_duration = dialog_box.text.length() / 30.0
+	$YapTimer.wait_time = text_duration + 5.0
 	$"Talking Boss".start_talk()
 	if tween:
 		tween.kill()
@@ -67,3 +71,12 @@ func yap():
 func _on_yap_timer_timeout():
 	dialog_box.visible_ratio = 0.0
 	$"Talking Boss".stop_talk()
+
+func end_level():
+	$EndLevel.start()
+	$B411.ball_speed = 0
+	$CanvasLayer/Curtains.show()
+	$AnimationPlayer.play("fade")
+	
+func _on_end_level_timeout():
+	get_tree().change_scene_to_file("res://Scenes/debriefLevel2.tscn")

--- a/Scripts/level_three.gd
+++ b/Scripts/level_three.gd
@@ -57,6 +57,7 @@ func evil_ball():
 
 func yap():
 	text_duration = dialog_box.text.length() / 30.0
+	$YapTimer.wait_time = text_duration + 5.0
 	if tween:
 		tween.kill()
 	tween = create_tween()

--- a/Scripts/level_two.gd
+++ b/Scripts/level_two.gd
@@ -60,14 +60,17 @@ func generators_remaining():
 func end_level_button():
 	dialog_box.text = "You’ve made a grave mistake, and a terrible enemy this day. B.411, you FOOL!"
 	yap()
+	BackgroundProcess.second_rebel()
+	end_level()
 	#detector.talk_trigger.emit("lvl two button")
 	
 func end_level_bricks():
-	pass
+	false_victory()
 	#detector.talk_trigger.emit("lvl two bricks")
 	
 func yap():
 	text_duration = dialog_box.text.length() / 30.0
+	$YapTimer.wait_time = text_duration + 5.0
 	$"Talking Boss".start_talk()
 	if tween:
 		tween.kill()
@@ -79,3 +82,21 @@ func yap():
 func _on_yap_timer_timeout():
 	dialog_box.visible_ratio = 0.0
 	$"Talking Boss".stop_talk()
+
+func end_level():
+	$EndLevel.start()
+	$B411.ball_speed = 0
+	$CanvasLayer/Curtains.show()
+	$AnimationPlayer.play("fade")
+	
+func false_victory():
+	$FalseVictory.start()
+	$B411.ball_speed = 0
+	$CanvasLayer/Curtains.show()
+	$AnimationPlayer.play("fade")
+
+func _on_end_level_timeout():
+	get_tree().change_scene_to_file("res://Scenes/debriefLevel3.tscn")
+
+func _on_false_victory_timeout():
+	pass #Set false victory scene

--- a/Scripts/main_menu.gd
+++ b/Scripts/main_menu.gd
@@ -14,7 +14,7 @@ func _process(delta):
 
 
 func _on_start_button_pressed():
-	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+	get_tree().change_scene_to_file("res://Scenes/debriefLevel1.tscn")
 
 
 func _on_quit_button_pressed():

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Game Jam 1"
-run/main_scene="res://Scenes/main_menu.tscn"
+run/main_scene="res://Scenes/intro.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
Basic intro cutscene and debrief scenes added, with links between scenes.
Text for cutscenes lack animation due to complications that introduced complexity; not vital for now.

Current scene flow order is as follows:
Intro > Main Menu > Debrief 1 > Level 1  >> Normal play >> Debrief 2 > Level 2
                                                          v Rebel >> Debrief 2B > Level 2B 
                                                                                                      v Rebel > Debrief 3 > Level 3

Still missing: false victory scene, level 3 win/loss conditions/scenes